### PR TITLE
adding missing moment dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "people",
   "version": "0.1.0",
   "private": true,
+  "homepage": "http://inphomercial.github.io/gente",
   "dependencies": {
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
@@ -9,9 +10,12 @@
     "react-dom": "^15.6.1"
   },
   "devDependencies": {
+    "gh-pages": "^1.0.0",
     "react-scripts": "1.0.10"
   },
   "scripts": {
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "lodash": "^4.17.4",
+    "moment": "^2.18.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1"
   },


### PR DESCRIPTION
Saving `moment` as a dependency since it was preventing `npm run build` from running and adding `npm run deploy` command so that project can be accessed on http://inphomercial.github.io/gente (@inphomercial, you'll have to run `npm run build` after you merge this PR and it should do everything for you.)